### PR TITLE
Fix: removed foldcolumn

### DIFF
--- a/autoload/leaderMapper.vim
+++ b/autoload/leaderMapper.vim
@@ -104,6 +104,7 @@ function! s:OpenMenu()
     setlocal nonumber
     setlocal norelativenumber
     setlocal signcolumn=no
+    setlocal foldcolumn=0
 
 endfunction
 


### PR DESCRIPTION
If foldcolumn is set in main nvim config, menu layout will break this way
![image](https://user-images.githubusercontent.com/32503439/102026928-f7278480-3db1-11eb-8a80-6adeb1648073.png)
Same, but with vim theme I use
![image](https://user-images.githubusercontent.com/32503439/102026975-4077d400-3db2-11eb-8221-f2ef368a6d08.png)
So, I just set foldcolumn to 0 in local nvim window.